### PR TITLE
The sed command requires an argument for the -i parameter on Mac OSX even if the argument is an empty string. This argument is not required on Linux.

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -32,7 +32,7 @@ task 'build', 'generate unified JavaScript file for whole Create', ->
   series [
     mergeDirs
     (sh "cat merged/*.js > examples/create.js")
-    (sh "sed -i 's/{{ VERSION }}/#{version}/' #{__dirname}/examples/create.js")
+    (sh "sed -i '' 's/{{ VERSION }}/#{version}/' #{__dirname}/examples/create.js")
     (sh "rm -r merged")
   ]
 
@@ -42,7 +42,7 @@ task 'min', 'minify the generated JavaScript file', ->
   series [
     mergeDirs
     (sh "cat merged/*.js > examples/create.js")
-    (sh "sed -i 's/{{ VERSION }}/#{version}/' #{__dirname}/examples/create.js")
+    (sh "sed -i '' 's/{{ VERSION }}/#{version}/' #{__dirname}/examples/create.js")
     (sh "rm -r merged")
     (sh "./node_modules/.bin/uglifyjs examples/create.js > examples/create-min.js")
   ]


### PR DESCRIPTION
I was trying to build the create library on a Mac and I kept running into this error

```
Executing sed -i 's/{{ VERSION }}/1.0.0alpha4/' /Users/jbeach/code/bergie/create/examples/create.js
{ [Error: Command failed: sed: 1: "/Users/jbeach/code/berg ...": invalid command code j
] killed: false, code: 1, signal: null }
sed: 1: "/Users/jbeach/code/berg ...": invalid command code j
```

A little googling lead me to this note on stackoverflow about the sed command requiring an argument to the -i parameter on Mac, but not Linux.

http://stackoverflow.com/questions/4247068/sed-command-failing-on-mac-but-works-on-linux

Hopefully this patch will run on Linux as well. I can't test it locally not having a Linux install.
