### PR TITLE
Rename 'Editable' widget to 'EditableEntity' widget and 'Editor' or 'Edi...

### DIFF
--- a/examples/create.js
+++ b/examples/create.js
@@ -22,7 +22,7 @@
   jQuery.widget('Midgard.midgardCreate', {
     // ## Configuration
     //
-    // Like most jQuery UI widgets, Create accepts various options 
+    // Like most jQuery UI widgets, Create accepts various options
     // when being instantiated.
     options: {
       // Initial toolbar rendering style: `full` or `minimized`.
@@ -38,7 +38,7 @@
       highlightColor: '#67cc08',
       // Widgets to use for editing various content types.
       editorWidgets: {
-        'default': 'hallo' 
+        'default': 'hallo'
       },
       // Additional editor options.
       editorOptions: {
@@ -777,20 +777,21 @@
   /*global jQuery:false _:false window:false VIE:false */
   'use strict';
 
-  // # Create editing widget
+  // Define Create's EditableEntity widget.
   jQuery.widget('Midgard.midgardEditable', {
     options: {
-      editables: [],
+      propertyEditors: {},
       collections: [],
       model: null,
-      editors: {
+      // the configuration (mapping and options) of property editor widgets
+      propertyEditorWidgetsConfiguration: {
         hallo: {
           widget: 'halloWidget',
           options: {}
         }
       },
-      // the available widgets by data type
-      widgets: {
+      // the available property editor widgets by data type
+      propertyEditorWidgets: {
         'default': 'hallo'
       },
       collectionWidgets: {
@@ -807,15 +808,60 @@
       language: null,
       // Current state of the Editable
       state: null,
-      // Callback function for validating changes between states. Receives the previous state, new state, possible predicate, and a callback
+      // Callback function for validating changes between states. Receives the previous state, new state, possibly property, and a callback
       acceptStateChange: true,
+      // Callback function for listening (and reacting) to state changes.
+      stateChange: null,
       // Callback function for decorating the full editable. Will be called on instantiation
-      decorate: null,
-      // Callback function for decorating a single editing widget. Will be called on editing widget instantiation.
-      decorateEditor: null
+      decorateEditableEntity: null,
+      // Callback function for decorating a single property editor widget. Will
+      // be called on editing widget instantiation.
+      decoratePropertyEditor: null,
+
+      // Deprecated.
+      editables: [], // Now `propertyEditors`.
+      editors: {}, // Now `propertyEditorWidgetsConfiguration`.
+      widgets: {} // Now `propertyEditorW
+    },
+
+    // Aids in consistently passing parameters to events and callbacks.
+    _params: function(predicate, extended) {
+      var entityParams = {
+        entity: this.options.model,
+        editableEntity: this,
+        entityElement: this.element,
+
+        // Deprecated.
+        editable: this,
+        element: this.element,
+        instance: this.options.model
+      };
+
+      var propertyParams = (predicate) ? {
+        predicate: predicate,
+        propertyEditor: this.options.propertyEditors[predicate],
+        propertyElement: this.options.propertyEditors[predicate].element,
+
+        // Deprecated.
+        property: predicate,
+        element: this.options.propertyEditors[predicate].element
+      } : {};
+
+      return _.extend(entityParams, propertyParams, extended);
     },
 
     _create: function () {
+      // Backwards compatibility:
+      // - this.options.propertyEditorWidgets used to be this.options.widgets
+      // - this.options.propertyEditorWidgetsConfiguration used to be
+      //   this.options.editors
+      if (this.options.widgets) {
+        this.options.propertyEditorWidgets = _.extend(this.options.propertyEditorWidgets, this.options.widgets);
+      }
+      if (this.options.editors) {
+        this.options.propertyEditorWidgetsConfiguration = _.extend(this.options.propertyEditorWidgetsConfiguration, this.options.editors);
+      }
+
       this.vie = this.options.vie;
       this.domService = this.vie.service(this.options.domService);
       if (!this.options.model) {
@@ -826,16 +872,23 @@
           widget.options.model = entities[0];
         });
       }
-      if (_.isFunction(this.options.decorate)) {
-        this.options.decorate({
-          editable: this,
-          element: this.element,
-          entity: this.options.model
-        });
+      if (_.isFunction(this.options.decorateEditableEntity)) {
+        this.options.decorateEditableEntity(this._params());
       }
     },
 
     _init: function () {
+      // Backwards compatibility:
+      // - this.options.propertyEditorWidgets used to be this.options.widgets
+      // - this.options.propertyEditorWidgetsConfiguration used to be
+      //   this.options.editors
+      if (this.options.widgets) {
+        this.options.propertyEditorWidgets = _.extend(this.options.propertyEditorWidgets, this.options.widgets);
+      }
+      if (this.options.editors) {
+        this.options.propertyEditorWidgetsConfiguration = _.extend(this.options.propertyEditorWidgetsConfiguration, this.options.editors);
+      }
+
       // Old way of setting the widget inactive
       if (this.options.disabled === true) {
         this.setState('inactive');
@@ -898,16 +951,13 @@
         this.enable();
       }
 
-      this._trigger('statechange', null, {
+      this._trigger('statechange', null, this._params(predicate, {
         previous: previous,
-        current: current,
-        instance: this.options.model,
-        predicate: predicate,
-        entityElement: this.element
-      });
+        current: current
+      }));
     },
 
-    findEditableElements: function (callback) {
+    findEditablePredicateElements: function (callback) {
       this.domService.findPredicateElements(this.options.model.id, jQuery(this.options.predicateSelector, this.element), false).each(callback);
     },
 
@@ -916,42 +966,39 @@
     },
 
     enable: function () {
-      var widget = this;
+      var editableEntity = this;
       if (!this.options.model) {
         return;
       }
 
-      this.findEditableElements(function () {
-        return widget._enableProperty(jQuery(this));
+      this.findEditablePredicateElements(function () {
+        editableEntity._enablePropertyEditor(jQuery(this));
       });
 
-      this._trigger('enable', null, {
-        instance: this.options.model,
-        entityElement: this.element
-      });
+      this._trigger('enable', null, this._params());
 
       _.each(this.domService.views, function (view) {
         if (view instanceof this.vie.view.Collection && this.options.model === view.owner) {
-          var property = view.collection.predicate;
+          var predicate = view.collection.predicate;
           var editableOptions = _.clone(this.options);
           editableOptions.state = null;
           var collection = this.enableCollection({
             model: this.options.model,
             collection: view.collection,
-            property: property,
-            definition: this.getAttributeDefinition(property),
+            property: predicate,
+            definition: this.getAttributeDefinition(predicate),
             view: view,
             element: view.el,
-            vie: widget.vie,
+            vie: editableEntity.vie,
             editableOptions: editableOptions
           });
-          widget.options.collections.push(collection);
+          editableEntity.options.collections.push(collection);
         }
       }, this);
     },
 
     disable: function () {
-      _.each(this.options.editables, function (editable) {
+      _.each(this.options.propertyEditors, function (editable) {
         this.disableEditor({
           widget: this,
           editable: editable,
@@ -959,7 +1006,11 @@
           element: jQuery(editable)
         });
       }, this);
+      this.options.propertyEditors = {};
+
+      // Deprecated.
       this.options.editables = [];
+
       _.each(this.options.collections, function (collectionWidget) {
         var editableOptions = _.clone(this.options);
         editableOptions.state = 'inactive';
@@ -973,108 +1024,89 @@
       }, this);
       this.options.collections = [];
 
-      this._trigger('disable', null, {
-        instance: this.options.model,
-        entityElement: this.element
-      });
+      this._trigger('disable', null, this._params());
     },
 
-    _enableProperty: function (element) {
+    _enablePropertyEditor: function (element) {
       var widget = this;
-      var propertyName = this.getElementPredicate(element);
-      if (!propertyName) {
+      var predicate = this.getElementPredicate(element);
+      if (!predicate) {
         return true;
       }
-      if (this.options.model.get(propertyName) instanceof Array) {
+      if (this.options.model.get(predicate) instanceof Array) {
         // For now we don't deal with multivalued properties in the editable
         return true;
       }
 
-      var editable = this.enableEditor({
+      var propertyElement = this.enablePropertyEditor({
         widget: this,
         element: element,
         entity: this.options.model,
-        property: propertyName,
+        property: predicate,
         vie: this.vie,
-        decorate: this.options.decorateEditor,
+        decorate: this.options.decoratePropertyEditor,
+        decorateParams: _.bind(this._params, this),
         changed: function (content) {
-          widget.setState('changed', propertyName);
+          widget.setState('changed', predicate);
 
           var changedProperties = {};
-          changedProperties[propertyName] = content;
+          changedProperties[predicate] = content;
           widget.options.model.set(changedProperties, {
             silent: true
           });
 
-          widget._trigger('changed', null, {
-            property: propertyName,
-            instance: widget.options.model,
-            element: element,
-            entityElement: widget.element
-          });
+          widget._trigger('changed', null, widget._params(predicate));
         },
         activating: function () {
-          widget.setState('activating', propertyName);
+          widget.setState('activating', predicate);
         },
         activated: function () {
-          widget.setState('active', propertyName);
-          widget._trigger('activated', null, {
-            property: propertyName,
-            instance: widget.options.model,
-            element: element,
-            entityElement: widget.element
-          });
+          widget.setState('active', predicate);
+          widget._trigger('activated', null, widget._params(predicate));
         },
         deactivated: function () {
-          widget.setState('candidate', propertyName);
-          widget._trigger('deactivated', null, {
-            property: propertyName,
-            instance: widget.options.model,
-            element: element,
-            entityElement: widget.element
-          });
+          widget.setState('candidate', predicate);
+          widget._trigger('deactivated', null, widget._params(predicate));
         }
       });
 
-      if (!editable) {
+      if (!propertyElement) {
         return;
       }
-      this._trigger('enableproperty', null, {
-        editable: editable,
-        property: propertyName,
-        instance: this.options.model,
-        element: element,
-        entityElement: this.element
-      });
+      var widgetType = propertyElement.data('createWidgetName');
+      this.options.propertyEditors[predicate] = propertyElement.data(widgetType);
 
-      this.options.editables.push(editable);
+      // Deprecated.
+      this.options.editables.push(propertyElement);
+
+      this._trigger('enableproperty', null, this._params(predicate));
     },
 
-    // returns the name of the widget to use for the given property
-    _editorName: function (data) {
-      if (this.options.widgets[data.property] !== undefined) {
-        // Widget configuration set for specific RDF predicate
-        return this.options.widgets[data.property];
+    // returns the name of the property editor widget to use for the given property
+    _propertyEditorName: function (data) {
+      if (this.options.propertyEditorWidgets[data.property] !== undefined) {
+        // Property editor widget configuration set for specific RDF predicate
+        return this.options.propertyEditorWidgets[data.property];
       }
 
-      // Load the widget configuration for the data type
+      // Load the property editor widget configuration for the data type
       var propertyType = 'default';
       var attributeDefinition = this.getAttributeDefinition(data.property);
       if (attributeDefinition) {
         propertyType = attributeDefinition.range[0];
       }
-      if (this.options.widgets[propertyType] !== undefined) {
-        return this.options.widgets[propertyType];
+      if (this.options.propertyEditorWidgets[propertyType] !== undefined) {
+        return this.options.propertyEditorWidgets[propertyType];
       }
-      return this.options.widgets['default'];
+      return this.options.propertyEditorWidgets['default'];
     },
 
-    _editorWidget: function (editor) {
-      return this.options.editors[editor].widget;
+    _propertyEditorWidget: function (editor) {
+      return this.options.propertyEditorWidgetsConfiguration[editor].widget;
     },
 
-    _editorOptions: function (editor) {
-      return this.options.editors[editor].options;
+    _propertyEditorOptions: function (editor) {
+      return this.options.propertyEditorWidgetsConfiguration[editor].options;
     },
 
     getAttributeDefinition: function (property) {
@@ -1088,15 +1120,20 @@
       return type.attributes.get(property);
     },
 
+    // Deprecated.
     enableEditor: function (data) {
-      var editorName = this._editorName(data);
+      return this.enablePropertyEditor(data);
+    },
+
+    enablePropertyEditor: function (data) {
+      var editorName = this._propertyEditorName(data);
       if (editorName === null) {
         return;
       }
 
-      var editorWidget = this._editorWidget(editorName);
+      var editorWidget = this._propertyEditorWidget(editorName);
 
-      data.editorOptions = this._editorOptions(editorName);
+      data.editorOptions = this._propertyEditorOptions(editorName);
       data.toolbarState = this.options.toolbarState;
       data.disabled = false;
 
@@ -1109,7 +1146,12 @@
       return jQuery(data.element);
     },
 
+    // Deprecated.
     disableEditor: function (data) {
+      return this.disablePropertyEditor(data);
+    },
+
+    disablePropertyEditor: function (data) {
       var widgetName = jQuery(data.element).data('createWidgetName');
 
       data.disabled = true;
@@ -1180,13 +1222,14 @@
   /*global jQuery:false _:false document:false */
   'use strict';
 
-  // # Base editing widget
+  // # Base property editor widget
   //
-  // This editing widget provides a very simplistic `contentEditable` editor
-  // that can be used as standalone, but should more usually be used as
-  // the baseclass for other editing widgets.
+  // This property editor widget provides a very simplistic `contentEditable`
+  // property editor that can be used as standalone, but should more usually be
+  // used as the base class for other property editor widgets.
+  // This property editor widget is only useful for textual properties!
   //
-  // Basic editing widgets on this is easy:
+  // Subclassing this base property editor widget is easy:
   //
   //     jQuery.widget('Namespace.MyWidget', jQuery.Create.editWidget, {
   //       // override any properties
@@ -1204,23 +1247,29 @@
     disable: function (disable) {
       this.element.attr('contenteditable', 'false');
     },
-    // called by the jquery ui plugin factory when creating the widget
-    // instance
+    // called by the jQuery UI plugin factory when creating the property editor
+    // widget instance
     _create: function () {
       this._registerWidget();
       this._initialize();
 
-      if (_.isFunction(this.options.decorate)) {
-        this.options.decorate({
-          editable: this.options.widget,
+      if (_.isFunction(this.options.decorate) && _.isFunction(this.options.decorateParams)) {
+        // TRICKY: we can't use this.options.decorateParams()'s 'propertyName'
+        // parameter just yet, because it will only be available after this
+        // object has been created, but we're currently in the constructor!
+        // Hence we have to duplicate part of its logic here.
+        this.options.decorate(this.options.decorateParams(null, {
+          propertyName: this.options.property,
+          propertyEditor: this,
+          propertyElement: this.element,
+          // Deprecated.
           editor: this,
           predicate: this.options.property,
-          entity: this.options.entity,
           element: this.element
-        });
+        }));
       }
     },
-    // called every time the widget is called
+    // called every time the property editor widget is called
     _init: function () {
       if (this.options.disabled) {
         this.disable();
@@ -1228,7 +1277,7 @@
       }
       this.enable();
     },
-    // override this function to initialize the widget functions
+    // override this function to initialize the property editor widget functions
     _initialize: function () {
       var self = this;
       this.element.bind('focus', function () {
@@ -1255,7 +1304,7 @@
         }
       });
     },
-    // used to register the widget name with the DOM element
+    // used to register the property editor widget name with the DOM element
     _registerWidget: function () {
       this.element.data("createWidgetName", this.widgetName);
     }

--- a/src/editingWidgets/jquery.Midgard.midgardEditableBase.js
+++ b/src/editingWidgets/jquery.Midgard.midgardEditableBase.js
@@ -8,13 +8,14 @@
   /*global jQuery:false _:false document:false */
   'use strict';
 
-  // # Base editing widget
+  // # Base property editor widget
   //
-  // This editing widget provides a very simplistic `contentEditable` editor
-  // that can be used as standalone, but should more usually be used as
-  // the baseclass for other editing widgets.
+  // This property editor widget provides a very simplistic `contentEditable`
+  // property editor that can be used as standalone, but should more usually be
+  // used as the base class for other property editor widgets.
+  // This property editor widget is only useful for textual properties!
   //
-  // Basic editing widgets on this is easy:
+  // Subclassing this base property editor widget is easy:
   //
   //     jQuery.widget('Namespace.MyWidget', jQuery.Create.editWidget, {
   //       // override any properties
@@ -32,23 +33,29 @@
     disable: function (disable) {
       this.element.attr('contenteditable', 'false');
     },
-    // called by the jquery ui plugin factory when creating the widget
-    // instance
+    // called by the jQuery UI plugin factory when creating the property editor
+    // widget instance
     _create: function () {
       this._registerWidget();
       this._initialize();
 
-      if (_.isFunction(this.options.decorate)) {
-        this.options.decorate({
-          editable: this.options.widget,
+      if (_.isFunction(this.options.decorate) && _.isFunction(this.options.decorateParams)) {
+        // TRICKY: we can't use this.options.decorateParams()'s 'propertyName'
+        // parameter just yet, because it will only be available after this
+        // object has been created, but we're currently in the constructor!
+        // Hence we have to duplicate part of its logic here.
+        this.options.decorate(this.options.decorateParams(null, {
+          propertyName: this.options.property,
+          propertyEditor: this,
+          propertyElement: this.element,
+          // Deprecated.
           editor: this,
           predicate: this.options.property,
-          entity: this.options.entity,
           element: this.element
-        });
+        }));
       }
     },
-    // called every time the widget is called
+    // called every time the property editor widget is called
     _init: function () {
       if (this.options.disabled) {
         this.disable();
@@ -56,7 +63,7 @@
       }
       this.enable();
     },
-    // override this function to initialize the widget functions
+    // override this function to initialize the property editor widget functions
     _initialize: function () {
       var self = this;
       this.element.bind('focus', function () {
@@ -83,7 +90,7 @@
         }
       });
     },
-    // used to register the widget name with the DOM element
+    // used to register the property editor widget name with the DOM element
     _registerWidget: function () {
       this.element.data("createWidgetName", this.widgetName);
     }

--- a/src/jquery.Midgard.midgardCreate.js
+++ b/src/jquery.Midgard.midgardCreate.js
@@ -22,7 +22,7 @@
   jQuery.widget('Midgard.midgardCreate', {
     // ## Configuration
     //
-    // Like most jQuery UI widgets, Create accepts various options 
+    // Like most jQuery UI widgets, Create accepts various options
     // when being instantiated.
     options: {
       // Initial toolbar rendering style: `full` or `minimized`.
@@ -38,7 +38,7 @@
       highlightColor: '#67cc08',
       // Widgets to use for editing various content types.
       editorWidgets: {
-        'default': 'hallo' 
+        'default': 'hallo'
       },
       // Additional editor options.
       editorOptions: {

--- a/test/midgardCreate.js
+++ b/test/midgardCreate.js
@@ -89,7 +89,7 @@ test('Create URL callback registration', function () {
 });
 
 test('Create edit events', function () {
-  expect(12);
+  expect(27);
   var fixture = jQuery('.create-edit-events');
 
   fixture.bind('midgardcreatestatechange', function (event, data) {
@@ -98,16 +98,29 @@ test('Create edit events', function () {
   });
 
   fixture.bind('midgardeditableenable', function (event, data) {
+    // Ensure backwards compatibility.
     ok(data.instance);
     ok(data.entityElement);
+
+    ok(data.entity, 'enabled properties have the Backbone model instance for the entity');
+    ok(data.editableEntity, 'enabled properties have the EditableEntity widget object for the entity');
+    ok(data.entityElement, 'enabled properties have the DOM element for the entity');
   });
 
   // We have two properties, so this will be called twice
   fixture.bind('midgardeditableenableproperty', function (event, data) {
-    ok(data.property);
+    // Ensure backwards compatibility.
+    ok(data.predicate);
     ok(data.instance);
     ok(data.element);
     ok(data.entityElement);
+
+    ok(data.entity, 'enabled properties have the Backbone model instance for the entity');
+    ok(data.editableEntity, 'enabled properties have the EditableEntity widget object for the entity');
+    ok(data.entityElement, 'enabled properties have the DOM element for the entity');
+    ok(data.predicate, 'enabled properties have the predicate of the property');
+    ok(data.propertyEditor, 'enabled properties have the property editor for the property');
+    ok(data.propertyElement, 'enabled properties have the DOM element for the property');
   });
 
   fixture.midgardCreate({
@@ -116,7 +129,7 @@ test('Create edit events', function () {
 });
 
 test('Create state change events', function () {
-  expect(20);
+  expect(41);
   var fixture = jQuery('.create-state-events');
 
   var previous = null;
@@ -133,22 +146,40 @@ test('Create state change events', function () {
 
   // Will be called once, when we go to edit state
   fixture.bind('midgardeditableenable', function (event, data) {
+    // Ensure backwards compatibility.
     ok(data.instance, 'enabled editables provide entity instance');
     ok(data.entityElement, 'enabled editables provide the entity element');
+
+    ok(data.entity, 'enabled properties have the Backbone model instance for the entity');
+    ok(data.editableEntity, 'enabled properties have the EditableEntity widget object for the entity');
+    ok(data.entityElement, 'enabled properties have the DOM element for the entity');
   });
 
   // Will be called twice, initially and then when returning to browse state
   fixture.bind('midgardeditabledisable', function (event, data) {
+    // Ensure backwards compatibility.
     ok(data.instance, 'disabled editables provide entity instance');
     ok(data.entityElement, 'disabled editables provide the entity element');
+
+    ok(data.entity, 'enabled properties have the Backbone model instance for the entity');
+    ok(data.editableEntity, 'enabled properties have the EditableEntity widget object for the entity');
+    ok(data.entityElement, 'enabled properties have the DOM element for the entity');
   });
 
   // We have two properties, so this will be called twice
   fixture.bind('midgardeditableenableproperty', function (event, data) {
+    // Ensure backwards compatibility.
     ok(data.property, 'enabled properties have property name');
     ok(data.instance, 'enabled properties have entity instance');
     ok(data.element, 'enabled properties have property element');
     ok(data.entityElement, 'enabled properties have entity element');
+
+    ok(data.entity, 'enabled properties have the Backbone model instance for the entity');
+    ok(data.editableEntity, 'enabled properties have the EditableEntity widget object for the entity');
+    ok(data.entityElement, 'enabled properties have the DOM element for the entity');
+    ok(data.predicate, 'enabled properties have the predicate of the property');
+    ok(data.propertyEditor, 'enabled properties have the property editor for the property');
+    ok(data.propertyElement, 'enabled properties have the DOM element for the property');
   });
 
   // Start in browse state


### PR DESCRIPTION
...ting' widget to 'PredicateEditor' widget. Mark all parameters and functions that don't explicitly adhere to this naming scheme as deprecated, but retain backwards compatibility.

Fixes #132.
