### PR TITLE
[guide] Rename 'Editable' widget to 'EditableEntity' widget and 'Editor' or 'Edi...

### DIFF
--- a/guide/_posts/2012-06-04-editable.md
+++ b/guide/_posts/2012-06-04-editable.md
@@ -5,22 +5,35 @@ name: editable
 source: "https://github.com/bergie/create/blob/master/src/jquery.Midgard.midgardEditable.js"
 published: true
 ---
-The `Midgard.midgardEditable` widget is responsible for loading widgets (for example, the [Hallo](http://hallojs.org) rich text editor) for editing various content elements, and synchronizing those with the underlying [VIE](http://viejs.org) entity instances.
+The `Midgard.midgardEditable` widget (or: *editable entity widget*) is responsible for loading *property editor widgets* (for example, the [Hallo](http://hallojs.org) rich text editor) for editing various content elements, and synchronizing those with the underlying [VIE](http://viejs.org) entity instances.
 
-Create.js will load the Editable widget automatically for all RDFa annotated entities on the page, but you can also do it manually:
+Create.js will load the EditableEntity widget automatically for all RDFa annotated entities on the page, but you can also do it manually:
 
     jQuery('[about]').midgardEditable({
       vie: new VIE()
     });
 
+Let's clarify the nomenclature to take away any possible confusion:
+
+- a `subject` is the identifier of an entity
+- a `predicate` is the identifier of a property of an entity
+- an `entity` is an instance of a `subject` that contains the `properties` identified for it by `(subject, predicate)` pairs
+- a `property` is an instance of a `predicate` for a given `entity` (and thus contains the value for that `predicate`)
+
+So, Create.js will instantiate an *editable entity widget* for each entity on the page, which in turn will then instantiate a *property editor widget* for each *property* within that *entity*.
+Note that it is possible to have multiple EditableEntity widgets for the same entity — you may need to do this because your entity may be spread all over the page, for example.
+
 ## Configuration
 
-* `widgets`: object telling which editor widget to load for which content type
+* `propertyEditorWidgets`: object telling which property editor widget to load for which content type
+* `propertyEditorWidgetsConfiguration`: object telling how each property editor widget should be configured
 * `collectionWidgets`: object telling which collection handling widget to load for which content type
 
 ## States
 
-The editable widget carries an editable entity through various different states and controls the behavior of the particular editor widgets as needed. There are various events signaling transitions between different states.
+The EditableEntity widget carries an editable entity through various different states and controls the behavior of the particular property editor widgets as needed. There are various events signaling transitions between different states.
+
+__Note:__ state handling of the EditableEntity widget and the PredicateEditor widgets it may contain still needs to be refined.
 
 * _Inactive_ - editable has been loaded but editor is not active. Entered via the `midgardeditabledisable` event
 * _Candidate_ - editor has been enabled for the editable. Entered via the `midgardeditableenable` and `midgardeditablenableproperty` events
@@ -31,20 +44,28 @@ The editable widget carries an editable entity through various different states 
 
 ## Events
 
-* `midgardeditableenable`: when an object has been made editable. Event data contains an object with key `instance` providing the Backbone model instance and `entityElement` providing the element containing the object
-* `midgardeditabledisable`: when an object has been made non-editable. Event data contains an object with key `instance` providing the Backbone model instance and `entityElement` providing the element containing the object
-* `midgardeditableactivated`: when a particular property of an object has been activated in an editor. Event data contains keys `property`, `instance`, `element` and `entityElement`
-* `midgardeditabledeactivated`: when a particular property of an object has been deactivated in an editor. Event data contains keys `property`, `instance`, `element` and `entityElement`
-* `midgardeditablechanged`: when a particular property of an object has been changed in an editor. Event data contains keys `property`, `instance`, `element` and `entityElement`
-* `midgardeditableenableproperty`: when an particular property of an object has been made editable. Event data contains keys
+All events below *always* contain the following event data:
 
-  * `property` (string),
-  * `instance` (object),
-  * `entityElement` (array)
-  * `element` (array)
-  * `editable` (array)
+* `entity`: the Backbone model instance for the entity
+* `editableEntity`: the EditableEntity widget object for the entity
+* `entityElement`: the DOM element for the entity
 
-Because of a limitation of jQuery UI, please note that this event can be trigger by the widget only. So, with this HTML structure:
+If an event is *specific to a property* of the entity, then it will also contain the following event data:
+
+* `predicate`: the identifying predicate for the property of the entity
+* `propertyEditor`: the PredicateEditor widget object for the predicate of the entity
+* `propertyElement`: the DOM element for the property of the entity
+
+Events:
+
+* `midgardeditableenable`: when an entity has been made editable.
+* `midgardeditabledisable`: when an entity has been made non-editable.
+* `midgardeditableactivated`: when a particular property of an entity has been activated in a property editor.
+* `midgardeditabledeactivated`: when a particular property of an entity has been deactivated in a property editor.
+* `midgardeditablechanged`: when a particular property of an entity has been changed in a property editor.
+* `midgardeditableenableproperty`: when a particular property of an entity has been made editable.
+
+Because of a limitation of jQuery UI, please note that this event can be triggered by the EntityEditable widget only. So, with this HTML structure:
 
     <article about="/my/article" typeof="sioc:Post">
         <header>
@@ -55,14 +76,14 @@ Because of a limitation of jQuery UI, please note that this event can be trigger
         </div>
     </article>
 
-    // this work
+    // this works (event triggered on the entity)
     jQuery('body article').bind('midgardeditableenableproperty',
         function(event, data) {
             console.log('i am called')
         }
     );
 
-    // this doesn't work
+    // this doesn't work (event triggered on a property of the entity)
     jQuery('body article .content').bind('midgardeditableenableproperty',
         function(event, data) {
             console.log('i am called');


### PR DESCRIPTION
...ting' widget to 'PredicateEditor' widget. Clarify docs, state the fundamental aspects explicitly, cleaned up the events docs.

Fixes #132.
