### PR TITLE
Pass PropertyEditor metadata (editor name and widget) that could be usef...

### DIFF
--- a/examples/create.js
+++ b/examples/create.js
@@ -1143,6 +1143,9 @@
       data.editorOptions = this._propertyEditorOptions(editorName);
       data.toolbarState = this.options.toolbarState;
       data.disabled = false;
+      // Pass metadata that could be useful for some implementations.
+      data.editorName = editorName;
+      data.editorWidget = editorWidget;
 
       if (typeof jQuery(data.element)[editorWidget] !== 'function') {
         throw new Error(editorWidget + ' widget is not available');

--- a/src/jquery.Midgard.midgardEditable.js
+++ b/src/jquery.Midgard.midgardEditable.js
@@ -374,6 +374,9 @@
       data.editorOptions = this._propertyEditorOptions(editorName);
       data.toolbarState = this.options.toolbarState;
       data.disabled = false;
+      // Pass metadata that could be useful for some implementations.
+      data.editorName = editorName;
+      data.editorWidget = editorWidget;
 
       if (typeof jQuery(data.element)[editorWidget] !== 'function') {
         throw new Error(editorWidget + ' widget is not available');


### PR DESCRIPTION
...ul for some implementations.
