### PR TITLE
PR #144 - Optional callback for EditableEntity.setState? 

### DIFF
--- a/src/jquery.Midgard.midgardEditable.js
+++ b/src/jquery.Midgard.midgardEditable.js
@@ -154,7 +154,10 @@
     //
     // State changes may carry optional context information in a JavaScript object. The payload of these context objects is not
     // standardized, and is meant to be set and used by the application controller
-    setState: function (state, predicate, context) {
+    //
+    // The callback parameter is optional and will be invoked after a state change has been accepted (after the 'statechange'
+    // event) or rejected.
+    setState: function (state, predicate, context, callback) {
       var previous = this.options.state;
       var current = state;
       if (current === previous) {
@@ -164,15 +167,21 @@
       if (this.options.acceptStateChange === undefined || !_.isFunction(this.options.acceptStateChange)) {
         // Skip state transition validation
         this._doSetState(previous, current, predicate, context);
+        if (_.isFunction(callback)) {
+          callback(true);
+        }
         return;
       }
 
       var widget = this;
       this.options.acceptStateChange(previous, current, predicate, context, function (accepted) {
-        if (!accepted) {
-          return;
+        if (accepted) {
+          widget._doSetState(previous, current, predicate, context);
         }
-        widget._doSetState(previous, current, predicate, context);
+        if (_.isFunction(callback)) {
+          callback(accepted);
+        }
+        return;
       });
     },
 


### PR DESCRIPTION
As wim is cleaning up edit.module, this came up again so i created this small patch / PR.
