### PR TITLE
Adding support of editorOptions for ckeditor

### DIFF
--- a/src/editingWidgets/jquery.Midgard.midgardEditableEditorCKEditor.js
+++ b/src/editingWidgets/jquery.Midgard.midgardEditableEditorCKEditor.js
@@ -33,6 +33,11 @@
       this.editor.on('afterCommandExec', function () {
         widget.options.changed(widget.editor.getData());
       });
+      this.editor.on('configLoaded', function() {
+        jQuery.each(widget.options.editorOptions, function(optionName, option) {
+          widget.editor.config[optionName] = option;
+        });
+      });
     },
 
     disable: function () {


### PR DESCRIPTION
I wanted different editor toolbars/plugins for ckeditor but it seams the ckeditor widget did not support id. so here is the support for it.

Sample usage:

``` javascript
    jQuery('body').midgardCreate('configureEditor', 'ckeditor_title', 'ckeditorWidget', { 'removePlugins' : 'colorbutton,find,flash,font, forms,iframe,image,newpage,removeformat, smiley,specialchar,stylescombo,templates' });
    jQuery('body').midgardCreate('setEditorForProperty', 'title', 'ckeditor_title');
```
