### PR TITLE
Notify changed to createjs also after the "blur" event.

### DIFF
--- a/src/editingWidgets/jquery.Midgard.midgardEditableEditorCKEditor.js
+++ b/src/editingWidgets/jquery.Midgard.midgardEditableEditorCKEditor.js
@@ -23,6 +23,7 @@
       });
       this.editor.on('blur', function () {
         widget.options.activated();
+        widget.options.changed(widget.editor.getData());
       });
       this.editor.on('key', function () {
         widget.options.changed(widget.editor.getData());


### PR DESCRIPTION
This PR changed that on ckeditors blur event createjs also gets informed about a change in content.

problem was that the "key" event only gets the data before the key you actually pressing gets to the editor, so widget.editor.getData only returns the data before the key press.
which results in, the last keystroke dont get saved.

this PR fixes that.
