### PR TITLE
Fix toolbar in Opera browser

### DIFF
--- a/themes/create-ui/css/create-ui.css
+++ b/themes/create-ui/css/create-ui.css
@@ -71,7 +71,6 @@ a.create-ui-toggle {
 
 .create-ui-toolbar-toolarea {
     clear: both;
-    content: "";
     display: table;
     width: 100%;
 }


### PR DESCRIPTION
Before this fix, create.js toolbar action buttons didn't display in latest stable Opera v12.14.

Now everything works as expected and buttons show up.
