### PR TITLE
allow null or false to be used as toolbar option - doing so does not enable the toolbar

### DIFF
--- a/src/jquery.Midgard.midgardCreate.js
+++ b/src/jquery.Midgard.midgardCreate.js
@@ -108,8 +108,11 @@
       if (!this.options.language) {
         this.options.language = jQuery('html').attr('lang');
       }
-
-      this._enableToolbar();
+      
+      if(this.options.toolbar) {
+        this._enableToolbar();
+      }
+      
       this._enableMetadata();
       this._saveButton();
       this._editButton();


### PR DESCRIPTION
I have a use case where I don't believe a toolbar is necessary. I am using only a save and edit button that are displayed at all times. For this I am using the `buttonContainer` and `templates` options to create the edit button and the `saveButton` option to create a save button. 
