### PR TITLE
alohaWidget: Trigger change event whenever the editable is modified

### DIFF
--- a/dist/create.js
+++ b/dist/create.js
@@ -3005,17 +3005,28 @@ window.midgardCreate.localize = function (id, language) {
       }
       editable.vieEntity = options.entity;
 
+      var checkEditableChanged;
+
+      function activeEditableChanged() {
+        if (Aloha.activeEditable.isModified()) {
+          options.changed(Aloha.activeEditable.getContents());
+          Aloha.activeEditable.setUnmodified();
+        }
+      }
+
       // Subscribe to activation and deactivation events
       Aloha.bind('aloha-editable-activated', function (event, data) {
         if (data.editable !== editable) {
           return;
         }
+        checkEditableChanged = window.setInterval(activeEditableChanged, 500);
         options.activated();
       });
       Aloha.bind('aloha-editable-deactivated', function (event, data) {
         if (data.editable !== editable) {
           return;
         }
+        window.clearInterval(checkEditableChanged);
         options.deactivated();
       });
 

--- a/src/editingWidgets/jquery.Midgard.midgardEditableEditorAloha.js
+++ b/src/editingWidgets/jquery.Midgard.midgardEditableEditorAloha.js
@@ -36,17 +36,28 @@
       }
       editable.vieEntity = options.entity;
 
+      var checkEditableChanged;
+
+      function activeEditableChanged() {
+        if (Aloha.activeEditable.isModified()) {
+          options.changed(Aloha.activeEditable.getContents());
+          Aloha.activeEditable.setUnmodified();
+        }
+      }
+
       // Subscribe to activation and deactivation events
       Aloha.bind('aloha-editable-activated', function (event, data) {
         if (data.editable !== editable) {
           return;
         }
+        checkEditableChanged = window.setInterval(activeEditableChanged, 500);
         options.activated();
       });
       Aloha.bind('aloha-editable-deactivated', function (event, data) {
         if (data.editable !== editable) {
           return;
         }
+        window.clearInterval(checkEditableChanged);
         options.deactivated();
       });
 


### PR DESCRIPTION
Aloha needs some special treatment to get notifications about every
content change. The smart content change event is not triggered for
formatting actions and other changes.

This change implements a way to get all modifications as mentioned
in https://github.com/alohaeditor/Aloha-Editor/issues/696
