### PR TITLE
hide metadata widget when not editing

### DIFF
--- a/src/jquery.Midgard.midgardCreate.js
+++ b/src/jquery.Midgard.midgardCreate.js
@@ -417,6 +417,8 @@
         return;
       }
 
+      var widget = this;
+
       jQuery('.create-ui-tool-metadataarea', this.element).midgardMetadata({
         vie: this.vie,
         localize: this.options.localize,
@@ -424,6 +426,10 @@
         editors: this.options.metadata,
         createElement: this.element,
         editableNs: 'midgardeditable'
+      });
+
+      this.element.on('midgardeditabledisable', function () {
+        jQuery('.create-ui-tool-metadataarea', widget.element).hide();
       });
     },
 


### PR DESCRIPTION
This is probably only a quick fix but I didn't want to create an issue without code ...

When leaving the edit mode by pressing the cancel button the metadata editor stays open an you can continue editing. 