### PR TITLE
Update locale_it.js

### DIFF
--- a/locale/locale_it.js
+++ b/locale/locale_it.js
@@ -9,7 +9,7 @@ window.midgardCreate.locale.it = {
   // Session-state buttons for the main toolbar
   'Save': 'Salva',
   'Saving': 'Salvataggio',
-  'Cancel': 'Cancella',
+  'Cancel': 'Esci',
   'Edit': 'Modifica',
   // Storage status messages
   'localModification': 'Articolo "<%= label %>" in questa pagina hanno modifiche locali',


### PR DESCRIPTION
'Cancella' in italian means delete.
i think it's quite misleading the actual meaning of the button
