### PR TITLE
Z-index only works with absolute or relative elements

### DIFF
--- a/themes/midgard-notifications/midgardnotif.css
+++ b/themes/midgard-notifications/midgardnotif.css
@@ -2,6 +2,7 @@
     width: 280px;
     z-index: 9999;
     color: white;
+    position: relative;
 }
 * html .midgardNotifications-container {
 	position: absolute;


### PR DESCRIPTION
Otherwise the notification box will be rendered *below* the elements on a page, since the `z-index` is not used.