### PR TITLE
Only set editor options if there are options

### DIFF
--- a/src/editingWidgets/jquery.Midgard.midgardEditableEditorCKEditor.js
+++ b/src/editingWidgets/jquery.Midgard.midgardEditableEditorCKEditor.js
@@ -36,9 +36,11 @@
         widget.options.changed(widget.editor.getData());
       });
       this.editor.on('configLoaded', function() {
-        jQuery.each(widget.options.editorOptions, function(optionName, option) {
-          widget.editor.config[optionName] = option;
-        });
+        if (widget.options.editorOptions !== undefined) {
+          jQuery.each(widget.options.editorOptions, function(optionName, option) {
+            widget.editor.config[optionName] = option;
+          });
+        }
       });
     },
 


### PR DESCRIPTION
Otherwise there is an error with `jQuery.each`, because it does not work with `undefined`.