### PR TITLE
 [BUGFIX] Fix behavior on blur

### DIFF
--- a/dist/create.js
+++ b/dist/create.js
@@ -3083,7 +3083,7 @@ window.midgardCreate.localize = function (id, language) {
         widget.options.activated();
       });
       this.editor.on('blur', function () {
-        widget.options.activated();
+        widget.options.deactivated();
         widget.options.changed(widget.editor.getData());
       });
       this.editor.on('change', function () {
@@ -3334,7 +3334,7 @@ window.midgardCreate.localize = function (id, language) {
         widget.options.activated();
       });
       this.editor.on('blur', function () {
-        widget.options.activated();
+        widget.options.deactivated();
         widget.options.changed(widget.editor.getContent());
       });
       this.editor.on('change', function () {

--- a/src/editingWidgets/jquery.Midgard.midgardEditableEditorCKEditor.js
+++ b/src/editingWidgets/jquery.Midgard.midgardEditableEditorCKEditor.js
@@ -29,7 +29,7 @@
         widget.options.activated();
       });
       this.editor.on('blur', function () {
-        widget.options.activated();
+        widget.options.deactivated();
         widget.options.changed(widget.editor.getData());
       });
       this.editor.on('change', function () {

--- a/src/editingWidgets/jquery.Midgard.midgardEditableEditorTinyMCE.js
+++ b/src/editingWidgets/jquery.Midgard.midgardEditableEditorTinyMCE.js
@@ -32,7 +32,7 @@
         widget.options.activated();
       });
       this.editor.on('blur', function () {
-        widget.options.activated();
+        widget.options.deactivated();
         widget.options.changed(widget.editor.getContent());
       });
       this.editor.on('change', function () {


### PR DESCRIPTION
Both CKeditor and TinyMCE seem to have incorrect behavior
on blur: activated is fired instead of deactivated (see also
https://github.com/bergie/create/issues/218).
